### PR TITLE
Fix a bug, that stopped execution of local test suite if any of the cond...

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -9,7 +9,7 @@ module.exports = function (files) {
 };
 
 function run (next, file) {
-    test.browser = file;
+    test.browser = 'node/jsdom';
     test.harness.once('end', function () {
         process.nextTick(next.ok)
     });


### PR DESCRIPTION
...itions fail.

Testling sets browser name to a name of a file, then writes a "fails" group named "node/jsdom" but never uses it.

```
 /Users/invizko/node_modules/testling/lib/output/text.js:59
         fails[key].push([ 'assert', res ]);
                    ^
 TypeError: Cannot call method 'push' of undefined
     at Handler.assert (/Users/invizko/node_modules/testling/lib/output/text.js:59:20)
     at /Users/invizko/node_modules/testling/lib/output/text.js:9:27
     at EventEmitter.push (/Users/invizko/node_modules/testling/index.js:26:5)
     at EventEmitter.assert (/Users/invizko/node_modules/testling/lib/test.js:64:10)
     at EventEmitter.deepEqual (/Users/invizko/node_modules/testling/lib/test.js:125:10)
     at [object Object].<anonymous> (/Users/invizko/Sites/icl/javascripts/lsd-specs/Testling/output/test.js:21973:34)
     at [object Object].toEqual (/Users/invizko/Sites/icl/javascripts/lsd-specs/Testling/output/test.js:20390:34)
     at [object Object].<anonymous> (/Users/invizko/Sites/icl/javascripts/lsd-specs/Testling/output/test.js:22619:34)
     at /Users/invizko/Sites/icl/javascripts/lsd-specs/Testling/output/test.js:21985:15
     at /Users/invizko/node_modules/testling/lib/test.js:26:5
 invizko:Testling:% mate /Users/invizko/node_modules/testling/lib
```
