### PR TITLE
allow browserify options

### DIFF
--- a/browser/prelude.js
+++ b/browser/prelude.js
@@ -2,6 +2,7 @@
     var xws = require('xhr-write-stream');
     var Stream = require('stream');
     var json = typeof JSON === 'object' ? JSON : require('jsonify');
+    var util = require('util')
     
     process.on = function () {};
     var ws = xws('/sock');
@@ -77,8 +78,8 @@
           }
         } else {
           msg = [].map.call(arguments, function (v) {
-            return JSON.stringify(v, null, 2)
-          })
+            return util.inspect(v)
+          }).join(' ')
         }
 
         process.stdout.write(msg + '\n');


### PR DESCRIPTION
This patch passes the options through to browserify,

I need it so that I can use `testling --debug test.js --browser=chrome`
and then get correct line numbers.
