### PR TITLE
Fix content length in proxy.js when response from server sends it as a string

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -79,7 +79,7 @@ function createServer (insert, skip, req, bounce) {
                 }, {})
             ;
             if (headers['content-length']) {
-                headers['content-length'] += insert.length;
+                headers['content-length'] = parseInt(headers['content-length'],10) + insert.length;
             }
             delete headers.etag;
             delete headers['last-modified'];


### PR DESCRIPTION
Like the title says - this one line fix will make proxying to servers that don't send an int as content-length work.
