### PR TITLE
Testling should specify the encoding when serving the page/bundle.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -32,11 +32,14 @@ var server = http.createServer(function (req, res) {
         req.on('end', res.end.bind(res));
     }
     else if (req.url === '/') {
-        res.setHeader('content-type', 'text/html');
-        res.end('<html><body><script src="/bundle.js"></script></body></html>');
+        res.setHeader('content-type', 'text/html; charset=utf-8');
+        res.end('<!DOCTYPE html>'
+              + '<html><head><meta charset="utf-8"></head>'
+              + '<body><script src="/bundle.js"></script></body>'
+              + '</html>');
     }
     else if (req.url === '/bundle.js') {
-        res.setHeader('content-type', 'application/javascript');
+        res.setHeader('content-type', 'application/javascript; charset=utf-8');
         res.end(prelude + '\n' + src);
     }
 });


### PR DESCRIPTION
Since Testling didn't specify the charset, this led to a plethora of random encoding errors if the libraries used anything outside of the ASCII charset. The same code would work or not on browsers with the same capabilities depending on whether the browser decided to treat the page as UTF-8 or not.

Specifying the charset gets rid of all that and gives us predictable behaviours. Yay
