### PR TITLE
Fix `scripts` field usage in package.json

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -63,8 +63,15 @@ if ((process.stdin.isTTY || argv._.length) && argv._[0] !== '-') {
             process.env.PATH = path.resolve(dir, 'node_modules/.bin')
                 + ':' + process.env.PATH
             ;
-            scripts = expanded.scripts;
-            
+            scripts = expanded.script;
+            if (scripts.length > 0) {
+                html = html.replace('__SCRIPTS__', function() {
+                    return scripts.map(function (s) {
+                        return '<script src="' + ent.encode(s) + '"></script>'
+                    }).join('\n');
+                });
+            }
+
             var args = expanded.file.concat('--debug');
             var ps = spawn('browserify', args, { cwd: dir });
             ps.stdout.pipe(concat(function (src) {
@@ -109,9 +116,7 @@ if ((process.stdin.isTTY || argv._.length) && argv._[0] !== '-') {
         html = '<html><body>'
             + '<script src="/__testling_prelude.js"></script>'
             + before
-            + scripts.map(function (s) {
-                return '<script src="' + ent.encode(s) + '"></script>'
-            }).join('\n')
+            + '__SCRIPTS__'
             + '<script src="/__testling_bundle.js"></script>'
             + after
             + '</body></html>'


### PR DESCRIPTION
You where misusing the `scripts` field in package.json.

As I commented on your code:
- [first comment](https://github.com/substack/testling/commit/c0a2bb5e5fd93ec16c42cc96601f9d8b6a57cfdd#commitcomment-3485550)
- [second comment](https://github.com/substack/testling/commit/c0a2bb5e5fd93ec16c42cc96601f9d8b6a57cfdd#commitcomment-3485552)

You need to use `expanded.script` and as `unglog` is async, we need to update the HTML after we got the right scripts.
I made a quickfix so I can update the html accordingly and hurra, the `scripts` fields works!
