### PR TITLE
Only launch headless browsers

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -212,7 +212,7 @@ function ready () {
     
     var opts = {
         headless: true,
-        browser: launch && launch.browsers && launch.browsers.local[0].name
+        browser: launch && launch.browsers && launch.browsers.local.filter(function(b){ return b.headless; })[0].name
     };
     var href = 'http://localhost:'
         + bouncer.address().port


### PR DESCRIPTION
Prevents `Error: spawn ENOENT` error when `launch.browsers.local[0]` isn't headless. Fixes #17 for OS X users with PhantomJS installed.