### PR TITLE
Use html5 doctype

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -273,7 +273,7 @@ function getHTML (cb) {
         after = '<script>mocha.run()</script>';
     }
     
-    cb('<html><head><meta charset="utf-8"></head><body>'
+    cb('<!doctype html><html><head><meta charset="utf-8"></head><body>'
         + '<pre id="__testling_output"></pre>'
         + '<script>' + prelude + '</script>'
         + before


### PR DESCRIPTION
Without a valid doctype, IE will use “quirks mode” which is bad times.
For example, it will make IE9 behave like IE8 so methods like
`Array.prototype.indexOf` will suddenly be missing.
