### PR TITLE
allow the user to specify the test harness via argv

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -31,7 +31,7 @@ var pending = 4;
 var dir = path.resolve(argv._[0] === '-' ? false : argv._[0] || process.cwd());
 var ecstatic = require('ecstatic')(dir);
 var resolve = require('resolve').sync;
-var pkg = { testling: {} };
+var pkg = { testling: { harness: argv.harness } };
 
 if ((process.stdin.isTTY || argv._.length) && argv._[0] !== '-') {
     try {


### PR DESCRIPTION
I currently need to run a few builds within the same project, with testling. To accomplish this I prepare the bundles with browserify, then pipe the output into testling. Unfortunately, the testling cli does not allow me to specify that I need the mocha harness.
