### PR TITLE
Implement preprocess option in the testling field

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -90,9 +90,27 @@ if ((process.stdin.isTTY || argv._.length) && argv._[0] !== '-') {
             scripts = expanded.script;
 
             if (expanded.file.length) {
-                var args = expanded.file.concat('--debug');
+                var spawnOpts = { cwd: dir, env: env };
+                var ps;
 
-                var ps = spawn('browserify', args, { cwd: dir, env: env });
+                if (pkg.testling.preprocess) {
+                  var cmd, ags;
+
+                  if (typeof pkg.testling.preprocess === 'string') {
+                    cmd = parseCommand(pkg.testling.preprocess);
+                    args = cmd.slice(1);
+                    cmd = cmd[0];
+                  } else {
+                    cmd = pkg.testling.preprocess.command;
+                    args = pkg.testling.preprocess.args;
+                  }
+
+                  ps = spawn(cmd, args, spawnOpts);
+                } else {
+                  var args = expanded.file.concat('--debug');
+                  ps = spawn('browserify', args, spawnOpts);
+                }
+
                 ps.stdout.pipe(concat(function (src) {
                     bundle = src;
                     htmlQueue.forEach(function (f) { getHTML(f) });

--- a/readme.markdown
+++ b/readme.markdown
@@ -120,6 +120,39 @@ The exit code of coverify is non-zero when there are unreachable expressions.
 
 Make sure you have [PhantomJS](https://github.com/ariya/phantomjs) installed; this is the headless browser that testling will run your tests in if you are not using the `-u` option.
 
+# custom preprocess command
+
+Its possible to configure testling to run a custom bundle command instead of
+the default(browserify --debug).  A simple use case is to prepend shims for
+testing a library in older browsers.
+
+For example, lets say you have created a library that uses ES5 features but
+needs to be tested in IE7. To test this library correctly the shims need to be
+prepended in the browserified bundle, which can be achieved doing something
+like this:
+
+```sh
+npm install --save-dev es5-shim json3
+```
+
+Then configure the "preprocess" option:
+
+```json
+{
+  "testling": {
+    "preprocess": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "browserify test/*.js | cat node_modules/json3/lib/json3.js node_modules/es5-shim/es5-sh{im,am}.js -"
+      ]
+    },
+  }
+}
+```
+
+The above runs browserify and prepend shims to the bundle served by testling.
+
 # install
 
 First, install `browserify` globally so that the `testling` command can find it


### PR DESCRIPTION
This option should make simple perform complex transformations in the bundle for testling. For example:

``` json
{
  "testling": {
    "preprocess": {
      "command": "./bundle.sh",
      "args": ["arg1", "arg2"]
    }
  }
}

```
