### PR TITLE
make windows compatible by using win-spawn

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -220,25 +220,6 @@ function ready () {
         return
     }
 
-    var browser =
-        launch &&
-        launch.browsers &&
-        (/linux|bsd/i.test(process.platform) // xvfb-run
-            ? launch.browsers.local[0]
-            : launch.browsers.local.filter(function(b) { return b.headless;
-            })[0]
-        );
-
-    if (!browser) {
-        console.error('No headless browser found.');
-        return process.exit(1);
-    }
-
-    var opts = {
-        headless: true,
-        browser: browser.name
-    };
-
     if (argv.bcmd || argv.x) {
         var cmd = parseCommand(argv.bcmd || argv.x);
         var ps = spawn(cmd[0], cmd.slice(1).concat(href));
@@ -254,6 +235,25 @@ function ready () {
         });
     }
     else {
+        var browser =
+            launch &&
+            launch.browsers &&
+            (/linux|bsd/i.test(process.platform) // xvfb-run
+                ? launch.browsers.local[0]
+                : launch.browsers.local.filter(function(b) { return b.headless;
+                })[0]
+            );
+
+        if (!browser) {
+            console.error('No headless browser found.');
+            return process.exit(1);
+        }
+
+        var opts = {
+            headless: true,
+            browser: browser.name
+        };
+
         launch(href, opts, function (err, ps) {
             if (err) return console.error(err);
         });

--- a/doc/testling_field.markdown
+++ b/doc/testling_field.markdown
@@ -98,6 +98,16 @@ Specify a string and it will be run:
 "preprocess": "./build.sh"
 ```
 
+You can also specify browserify transformations and other processing options in `package.json`.
+An example how to do file inlining for your test bundles with [brfs](https://github.com/substack/brfs):
+
+``` json
+"browserify": { "transform": ["brfs"] },
+"testling": {
+    "files": "test.js",
+    ....
+```
+
 # server
 
 If you have a server-side element of your browser tests, you can use the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testling",
   "description": "write tests for browser code",
-  "version": "1.6.0",
+    "version" : "1.6.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/substack/testling.git"


### PR DESCRIPTION
on windows, spawn doesnt work well with javascript commands (like 'browserify'), but win-spawn module fixes that, and on unix passes through to child_process.spawn
