### PR TITLE
fix broken -x option

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -220,25 +220,6 @@ function ready () {
         return
     }
 
-    var browser =
-        launch &&
-        launch.browsers &&
-        (/linux|bsd/i.test(process.platform) // xvfb-run
-            ? launch.browsers.local[0]
-            : launch.browsers.local.filter(function(b) { return b.headless;
-            })[0]
-        );
-
-    if (!browser) {
-        console.error('No headless browser found.');
-        return process.exit(1);
-    }
-
-    var opts = {
-        headless: true,
-        browser: browser.name
-    };
-
     if (argv.bcmd || argv.x) {
         var cmd = parseCommand(argv.bcmd || argv.x);
         var ps = spawn(cmd[0], cmd.slice(1).concat(href));
@@ -254,6 +235,25 @@ function ready () {
         });
     }
     else {
+        var browser =
+            launch &&
+            launch.browsers &&
+            (/linux|bsd/i.test(process.platform) // xvfb-run
+                ? launch.browsers.local[0]
+                : launch.browsers.local.filter(function(b) { return b.headless;
+                })[0]
+            );
+
+        if (!browser) {
+            console.error('No headless browser found.');
+            return process.exit(1);
+        }
+
+        var opts = {
+            headless: true,
+            browser: browser.name
+        };
+
         launch(href, opts, function (err, ps) {
             if (err) return console.error(err);
         });


### PR DESCRIPTION
Currently, the `-x` command always errors out with the message "No headless browser found".

This is because you only set the `launch` variable if you didn't pass the x flag: https://github.com/substack/testling/blob/master/bin/cmd.js#L194-203

However, currently you check if `launch` exists whether you need it or not and, if it doesn't, you error out.

I moved all of the code for setting up the options for `browser-launcher` into the else statement where it's executed, since it's not needed in other places.
