### PR TITLE
More informative output if no suitable browser found.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -259,7 +259,11 @@ function ready () {
             );
 
         if (!browser) {
-            console.error('No headless browser found.');
+            console.error('No suitable browser found.');
+            console.log('## AVAILABLE BROWSERS ##');
+            console.log(launch.browsers);
+            console.log('Did you install some additional browsers? Try removing ~/.config/browser-launcher/config.json to re-detect.');
+            console.log('PS! Only headless browsers supported on Darwin/OSX.');
             return process.exit(1);
         }
 


### PR DESCRIPTION
After my initial run of testling I added some additional browsers including phantomjs. Re-running testling just kept reporting "No headless browser found.". I eventually discovered this was because browser-launcher was continually using  ~/.config/browser-launcher/config.json with the old browser set.

So I added some more informative output. It probably needs some modifications :smile_cat: 
