### PR TITLE
Ability to tell the browser to connect to a specific host and port.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -198,7 +198,7 @@ var bouncer = bouncy(function (req, res, bounce) {
         bounce(customServer.port, { headers: { connection: 'close' } });
     }
 });
-bouncer.listen(0, ready);
+bouncer.listen(argv.port || 0, ready);
 
 if ((argv.x || argv.bcmd) && typeof (argv.x || argv.bcmd) === 'boolean') {
     console.error('-x expects an argument');
@@ -224,7 +224,7 @@ function ready () {
         return;
     }
 
-    var href = 'http://localhost:'
+    var href = 'http://' + (argv.host || 'localhost') + ':'
         + bouncer.address().port
         + '/__testling?'
         + qs.stringify({ show: Boolean(argv.show) })

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -9,11 +9,15 @@ testling field.
 OPTIONS are:
 
      --html  Instead of launching a server, show the generated html.
-     
+
   --no-show  Don't render the console.log() output to the document body.
- 
+
          -u  Instead of launching a browser, print the url to visit so you can
              open the browser yourself.
 
          -x  Launch a browser with an explicit command. By default, chrome or
              firefox is launched by searching your $PATH.
+
+     --host  Set up the testling url on a specific hostname. Default: localhost
+
+     --port  Set up the testling url on a specific port

--- a/readme.markdown
+++ b/readme.markdown
@@ -61,14 +61,18 @@ testling field.
 OPTIONS are:
 
      --html  Instead of launching a server, show the generated html.
-     
+
   --no-show  Don't render the console.log() output to the document body.
- 
+
          -u  Instead of launching a browser, print the url to visit so you can
              open the browser yourself.
 
          -x  Launch a browser with an explicit command. By default, chrome or
              firefox is launched by searching your $PATH.
+
+     --host  Set up the testling url on a specific hostname. Default: localhost
+
+     --port  Set up the testling url on a specific port
 ```
 
 # testling field


### PR DESCRIPTION
When using the testling command to test browsers running in Virtual Machines (ie. IE), the URL that gets generated is always `localhost`. This will resolve to `localhost` in the VM, which obviously won't work.

This PR allows you to override the hostname that is provided to the browser when it is launched, as well as the port too.

I'm using testling with the [iectrl](https://github.com/xdissent/iectrl) command line tool to automatically launch IE in a VirtualBox VM, and then to pass it the URL, like so:

``` bash
# run test in ie9 and then close the browser (10.0.2.2 is the host IP that ievms initializes)
$ browserify test/ie.js | testling --host=10.0.2.2 -x 'iectrl open -s 9'; iectrl close
```

It's also useful to be able to hard code the port if you are continually debugging a test, so you can just refresh the browser with the same port rather than use the randomly assigned ports.

``` bash
# listen on port 9000
$ browserify test/ie.js | testling --host=10.0.2.2 --port 9000 -u
http://10.0.2.2:9000/__testling?show=true
```
