### PR TITLE
Fix 404 url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.7.6",
     "repository": {
         "type": "git",
-        "url": "git://github.com/tape-testling/testling.git"
+        "url": "git://github.com/tape-testing/testling.git"
     },
     "browserify": "browser.js",
     "bin": {


### PR DESCRIPTION
Fix broken link on https://www.npmjs.com/package/testling,
to make the repo easier to discover.